### PR TITLE
File URL Fix to Work on OSX, Windows, and Linux

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,15 +1,21 @@
 const { app, BrowserWindow, ipcMain } = require("electron")
+const path = require('path');
+const url = require('url');
 
 var knex = require("knex")({
 	client: "sqlite3",
 	connection: {
-		filename: "./database.sqlite"
+		filename: path.join(__dirname, 'database.sqlite')
 	}
 });
 
 app.on("ready", () => {
 	let mainWindow = new BrowserWindow({ height: 800, width: 800, show: false })
-	mainWindow.loadURL(`file://${__dirname}/main.html`)
+	mainWindow.loadURL(url.format({
+		pathname: path.join(__dirname, 'main.html'),
+		protocol: 'file',
+		slashes: true
+	}));
 	mainWindow.once("ready-to-show", () => { mainWindow.show() })
 
 	ipcMain.on("mainWindowLoaded", function () {


### PR DESCRIPTION
Changed how URLs were referenced for files so that the references are not specific to OSX. This program should work for Windows computers now too (a couple of comments on the youtube page asked about difficulty running on Windows).