### PR TITLE
Updated nodeIntegration to true.

### DIFF
--- a/index.js
+++ b/index.js
@@ -10,7 +10,14 @@ var knex = require("knex")({
 });
 
 app.on("ready", () => {
-	let mainWindow = new BrowserWindow({ height: 800, width: 800, show: false })
+	let mainWindow = new BrowserWindow({ 
+		height: 800, 
+		width: 800, 
+		show: false,
+		webPreferences: {
+            		nodeIntegration: true
+        	}
+	})
 	mainWindow.loadURL(url.format({
 		pathname: path.join(__dirname, 'main.html'),
 		protocol: 'file',


### PR DESCRIPTION
As of version 5, the default for nodeIntegration changed from true to false. I have manually set it to true under webPreferences in the set up of mainWindow.
Without this, require() does not work when used in the script tag in main.html.