### PR TITLE
nodeIntegration needed

### DIFF
--- a/index.js
+++ b/index.js
@@ -10,7 +10,7 @@ var knex = require("knex")({
 });
 
 app.on("ready", () => {
-	let mainWindow = new BrowserWindow({ height: 800, width: 800, show: false })
+	let mainWindow = new BrowserWindow({ height: 800, width: 800, show: false , webPreferences: {nodeIntegration: true}})
 	mainWindow.loadURL(url.format({
 		pathname: path.join(__dirname, 'main.html'),
 		protocol: 'file',


### PR DESCRIPTION
newer versions of node.js change default nodeIntegration to false, this leads to an error about require() in main.html.
By setting this to true let's the app start again. :)